### PR TITLE
Fixed bug: Volume control works now for mbrola voices

### DIFF
--- a/src/Settings.py
+++ b/src/Settings.py
@@ -25,7 +25,7 @@ from gettext import gettext as _
 cmdEspeak = '/usr/bin/espeak'
 argsEspeak = '-a %v -p %p -s %s -g %d -v %l -f %f --pho'
 cmdMbrola = '/usr/bin/mbrola'
-argsMbrola = '-e %l -'
+argsMbrola = '-v %v -e %l -'
 
 config = None
 confdir = os.path.join(xdg_config_home, 'gespeaker')

--- a/src/gespeakerUI.py
+++ b/src/gespeakerUI.py
@@ -477,6 +477,7 @@ class gespeakerUI(object):
         self.espeak.play(cmd, self.cmdPlayer, self.recordToFile)
       else:
         args = {
+          '%v': str(int(self.hscVolume.get_value())/100.), 
           '%l': '%s/%s/%s' % (
             Settings.get('VoicesmbPath'), 
             language.replace('mb-', '', 1),


### PR DESCRIPTION
The Advanced settings/Volume control did not affect the volume of the output sound when used with mbrola voices because the volume parameter was only supplied to espeak (-a flag) and not to mbrola (-v flag).
